### PR TITLE
jupyterlab 3.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.9" %}
+{% set version = "3.3.1" %}
 
 package:
   name: jupyterlab
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jupyterlab/jupyterlab-{{ version }}.tar.gz
-  sha256: 65ddc34e5da1a764606e38c4f70cf9d4ac1c05182813cf0ab2dfea312c701124
+  sha256: ce482799379c70aa87e63b59e2c5379779ce18658b92460cd20bb44154865973
 build:
   noarch: python
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
-{% set version = "3.3.1" %}
+{% set name = "jupyterlab" %}
+{% set version = "3.3.2" %}
 
 package:
-  name: jupyterlab
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jupyterlab/jupyterlab-{{ version }}.tar.gz
-  sha256: ce482799379c70aa87e63b59e2c5379779ce18658b92460cd20bb44154865973
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3c716bf5592cb28c5c55c615c6e5bd3efc71898f6957d13719b56478bbbb587a
+
 build:
   noarch: python
   number: 0
   # nodejs >=14,!=15.*,<17 currently isn't available on s390x.
-  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install --install-option="--skip-npm" . -vv
   entry_points:
     - jupyter-lab = jupyterlab.labapp:main
@@ -38,7 +39,7 @@ requirements:
     - jinja2 >=2.1
     - jupyter_core
     - jupyter_server >=1.4,<2
-    - jupyterlab_server >=2.3,<3
+    - jupyterlab_server >=2.10,<3
     - nbclassic >=0.2,<1
     - packaging
     - python >=3.7


### PR DESCRIPTION
Update jupyterlab to 3.3.2

https://github.com/jupyterlab/jupyterlab/blob/v3.3.2/pyproject.toml
https://github.com/jupyterlab/jupyterlab/blob/v3.3.2/setup.cfg
https://github.com/jupyterlab/jupyterlab/blob/v3.3.2/setup.py

Actions:
1. Use jinja2 templates for source/url
2. Remove skip s390x as it's a noarch package
3. Udate run dependencies: `jupyterlab_server >=2.10,<3`