### PR TITLE
jupyterlab 3.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,13 @@ requirements:
     - ipython
     - jinja2 >=2.1
     - jupyter_core
-    - jupyter_server >=1.16,<2
+    - jupyter_server >=1.16,<3
     - jupyterlab_server >=2.10,<3
     - nbclassic
     - notebook <7
     - packaging
     - python
+    - tomli
     - tornado >=6.1.0
 
 test:
@@ -88,9 +89,7 @@ about:
   dev_url: https://github.com/jupyterlab/jupyterlab
   description: >
     JupyterLab is the next-generation user interface for Project Jupyter. It offers all the familiar building blocks of the classic Jupyter Notebook (notebook, terminal, text editor, file browser, rich outputs, etc.) in a flexible and powerful user inteface. Eventually, JupyterLab will replace the classic Jupyter Notebook.
-
     JupyterLab can be extended using extensions that are npm packages and use our public APIs. You can search for the GitHub topic or npm keyword `jupyterlab-extension` to find extensions. To learn more about extensions, see our user documentation.
-
     JupyterLab is suitable for general usage. For JupyterLab extension developers, the extension APIs will continue to evolve.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.4.4" %}
+{% set version = "3.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5a2a0fdd22bd8628ad45b618e3520387c32a4818e3af112dbad1f649304dfc20
+  sha256: e02556c8ea1b386963c4b464e4618aee153c5416b07ab481425c817a033323a2
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** [PKG-730](https://anaconda.atlassian.net/browse/PKG-730) (jupyterlab-3.5.0)

**The upstream data:**
Github releases:  https://github.com/jupyterlab/jupyterlab/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyterlab/jupyterlab/compare/v3.4.4...v3.5.0)
License: https://github.com/jupyterlab/jupyterlab/blob/master/LICENSE
Changelog: https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md
Requirements:
 * setup.cfg:  https://github.com/jupyterlab/jupyterlab/blob/v3.5.0/setup.cfg
 *  pyproject.toml:  https://github.com/jupyterlab/jupyterlab/blob/v3.5.0/pyproject.toml

**_Actions:_**

1. Update jupyter_server  pinning
2. Add tomli to run
3. Remove empty lines

**_Notes:_**
 * It depends on `jupyterlab_server` https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/pull/19

**Package's statistics**
<details>

 * Priority B | effort: hard | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.5.0
 * Release on PyPi:
    * version: 3.5.0
    * date: 2022-10-24T08:12:07
* [PyPi history](https://pypi.org/project/jupyterlab/#history)
 * Popularity: 
    * 3 months downloads: 834618.0
    * All time:  6856264 downloads -  jupyterlab  3.5.0  An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyterlab/jupyterlab/tree/v3.5.0 exists
4. - [x] https://github.com/jupyterlab/jupyterlab is present
5. - [ ] Check the pinnings
6. - [x] https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md exists
7. - [x] Additional research
    https://github.com/jupyterlab/jupyterlab/issues
    200
8. - [x] `dev_url` is present
    https://github.com/jupyterlab/jupyterlab
9. - [x] `doc_url` error:
    https://jupyterlab.readthedocs.io
    302
10. - [ ] Verify that the `build_number` is correct
11. - [x] has `setuptools`
12. - [x] has `wheel`
13. - [x] `pip` in test
14. - [x] Verify the test section
15. - [x] Verify if the package is `architecture specific`
16. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

18. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyterlab-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/tree/3.5.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyterlab)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyterlab-feedstock/compare/main...AnacondaRecipes:3.5.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/compare/master...AnacondaRecipes:3.5.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyterlab-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.5.0 git@github.com:AnacondaRecipes/jupyterlab-feedstock.git
```
