### PR TITLE
jupyterlab 3.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.5.0" %}
+{% set version = "3.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e02556c8ea1b386963c4b464e4618aee153c5416b07ab481425c817a033323a2
+  sha256: 59a1b2d79d4b3ebee4d997c8bed8cf450f460c7c35f46b613a93f0b7712b47fc
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 6ab5c81..feee5bf 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.5.0" %}
+{% set version = "3.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e02556c8ea1b386963c4b464e4618aee153c5416b07ab481425c817a033323a2
+  sha256: 59a1b2d79d4b3ebee4d997c8bed8cf450f460c7c35f46b613a93f0b7712b47fc
 
 build:
   number: 0

```

**Jira ticket:** [PKG-858
PKG-756
PKG-730
PKG-342
PKG-108](https://anaconda.atlassian.net/browse/PKG-858
https://anaconda.atlassian.net/browse/PKG-756
https://anaconda.atlassian.net/browse/PKG-730
https://anaconda.atlassian.net/browse/PKG-342
https://anaconda.atlassian.net/browse/PKG-108) (jupyterlab
arrow
jupyterlab
jupyterlab
jupyterlab-3.5.1

3.5.0

2.2.10)

**The upstream data:**
Github releases:  https://github.com/jupyterlab/jupyterlab/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyterlab/jupyterlab/compare/3.5.0\.\.\.3.5.1)
License: https://github.com/jupyterlab/jupyterlab/blob/master/LICENSE
Changelog: https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/jupyterlab/jupyterlab/blob/v3.5.1/setup.py
 *  pyproject.toml:  https://github.com/jupyterlab/jupyterlab/blob/v3.5.1/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: hard | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.5.1
 * Release on PyPi:
    * version: 3.5.2
    * date: 2022-12-19T12:21:46
* [PyPi history](https://pypi.org/project/jupyterlab/#history)
 * Popularity: 
    * 3 months downloads: 1038473.0
    * All time:  7026737 downloads -  jupyterlab  3.5.2  An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyterlab/jupyterlab/tree/v3.5.1 exists
2. - [ ] The upstream url error:
    https://github.com/jupyterlab/jupyterlab
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/jupyterlab/jupyterlab/tree/v3.5.1
    200
5. - [ ] Additional research
    https://github.com/jupyterlab/jupyterlab/issues
    
6. - [ ] `dev_url` error:
    https://github.com/jupyterlab/jupyterlab
    
7. - [ ] `doc_url` error:
    https://jupyterlab.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [ ] license_file doesn't exist!

16. - [x] license_family BSD is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check GUI app:**

<details>
**GUI app check**

Recommend to make testing in c3i_test2 channel!
../aggregate/jupyterlab is a GUI aplication

**End GUI check**

</details>

**Check dependency issues:**

<details>
../aggregate/jupyterlab-feedstock/recipe/meta.yaml
Dependencies: ['tornado >=6.1.0', 'jupyter_server >=1.16,<3', 'tomli', 'wheel', 'notebook <7', 'nbclassic', 'jinja2 >=2.1', 'packaging', 'pip', 'jupyter_core', 'jupyterlab_server >=2.10,<3', 'jupyter-packaging >=0.9,<2', 'setuptools', 'ipython', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: unexpected char '\\' at 1623
None**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyterlab-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/tree/3.5.1)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyterlab)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyterlab-feedstock/compare/main...AnacondaRecipes:3.5.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/compare/master...AnacondaRecipes:3.5.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyterlab-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.5.1 git@github.com:AnacondaRecipes/jupyterlab-feedstock.git
```
