### PR TITLE
jupyterlab 3.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
 
 test:
   requires:
-    - nodejs >=14,!=15.*,<17
+    - nodejs >=14,!=15.*,!=17.*,<19
     - pip
     - ripgrep
   imports:
@@ -70,11 +70,11 @@ test:
     - cat serverextensions | rg "jupyterlab.*{{ version.replace(".", "\\.") }}.*OK"   # [not win]
     - jupyter lab build --dev-build=False --minimize=False
     - jupyter lab clean
-  #downstreams:
+  downstreams:
     # Additional testing for downstreams packages: ipympl, plotly, and pyviz_comms
-    #- ipympl
-    #- plotly
-    #- pyviz_comms
+    - ipympl
+    - plotly
+    - pyviz_comms
 
 about:
   home: https://github.com/jupyterlab/jupyterlab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,11 +70,11 @@ test:
     - cat serverextensions | rg "jupyterlab.*{{ version.replace(".", "\\.") }}.*OK"   # [not win]
     - jupyter lab build --dev-build=False --minimize=False
     - jupyter lab clean
-  downstreams:
+  #downstreams:
     # Additional testing for downstreams packages: ipympl, plotly, and pyviz_comms
-    - ipympl
-    - plotly
-    - pyviz_comms
+    #- ipympl
+    #- plotly
+    #- pyviz_comms
 
 about:
   home: https://github.com/jupyterlab/jupyterlab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.5.0" %}
+{% set version = "3.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e02556c8ea1b386963c4b464e4618aee153c5416b07ab481425c817a033323a2
+  sha256: 10ac094215ffb872ddffbe2982bf1c039a79fecc326e191e7cc5efd84f331dad
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** [PKG-858](https://anaconda.atlassian.net/browse/PKG-858) (jupyterlab-3.5.2)

**The upstream data:**
Github releases:  https://github.com/jupyterlab/jupyterlab/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyterlab/jupyterlab/compare/v3.5.0...v3.5.2)
License: https://github.com/jupyterlab/jupyterlab/blob/master/LICENSE
Changelog: https://github.com/jupyterlab/jupyterlab/blob/master/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/jupyterlab/jupyterlab/blob/v3.5.2/setup.py
 * setup.cfg: https://github.com/jupyterlab/jupyterlab/blob/v3.5.2/setup.cfg
 *  pyproject.toml:  https://github.com/jupyterlab/jupyterlab/blob/v3.5.2/pyproject.toml

**_Actions:_**

- Fix pinning of nodejs in test/requires


**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: hard | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.5.2
 * Release on PyPi:
    * version: 3.5.2
    * date: 2022-12-19T12:21:46
* [PyPi history](https://pypi.org/project/jupyterlab/#history)
 * Popularity: 
    * 3 months downloads: 1038473.0
    * All time:  7034343 downloads -  jupyterlab  3.5.2  An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyterlab/jupyterlab/tree/v3.5.2 exists
2. - [ ] The upstream url error:
    https://github.com/jupyterlab/jupyterlab
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/jupyterlab/jupyterlab/tree/v3.5.2
    200
5. - [ ] Additional research
    https://github.com/jupyterlab/jupyterlab/issues
    
6. - [ ] `dev_url` error:
    https://github.com/jupyterlab/jupyterlab
    
7. - [ ] `doc_url` error:
    https://jupyterlab.readthedocs.io
    
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [ ] license_file doesn't exist!

16. - [x] license_family BSD is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check GUI app:**

<details>
**GUI app check**

Recommend to make testing in c3i_test2 channel!
../aggregate/jupyterlab is a GUI aplication

**End GUI check**

</details>

**Check dependency issues:**

<details>
../aggregate/jupyterlab-feedstock/recipe/meta.yaml
Dependencies: ['ipython', 'tomli', 'setuptools', 'nbclassic', 'tornado >=6.1.0', 'jupyter-packaging >=0.9,<2', 'wheel', 'pip', 'jupyter_core', 'python', 'packaging', 'notebook <7', 'jinja2 >=2.1', 'jupyter_server >=1.16,<3', 'jupyterlab_server >=2.10,<3']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyterlab-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/tree/3.5.2)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyterlab)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyterlab-feedstock/compare/main...AnacondaRecipes:3.5.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/compare/master...AnacondaRecipes:3.5.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyterlab-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.5.2 git@github.com:AnacondaRecipes/jupyterlab-feedstock.git
```
