### PR TITLE
jupyterlab 3.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.5.3" %}
+{% set version = "3.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 51e889448ae194eeef8e50f63f5c4f487f728f477befe436e9749672f7511dbe
+  sha256: aee98c174180e98a30470297d10b959e8e64f2288970c0de65f0a6d2b4807034
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 082649b..b0f573a 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.5.3" %}
+{% set version = "3.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 51e889448ae194eeef8e50f63f5c4f487f728f477befe436e9749672f7511dbe
+  sha256: aee98c174180e98a30470297d10b959e8e64f2288970c0de65f0a6d2b4807034
 
 build:
   number: 0

```



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyterlab-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/tree/3.6.1)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyterlab)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyterlab-feedstock/compare/main...AnacondaRecipes:3.6.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyterlab-feedstock/compare/master...AnacondaRecipes:3.6.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyterlab-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.6.1 git@github.com:AnacondaRecipes/jupyterlab-feedstock.git
```
