### PR TITLE
update to 3.6.7

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "3.6.3" %}
+{% set version = "3.6.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 373e9cfb8a72edd294be14f16662563a220cecf0fb26de7aab1af9a29b689b82
+  sha256: 2fadeaec161b0d1aec19f17721d8b803aef1d267f89c8b636b703be14f435c8f
 
 build:
   number: 0
   # nodejs >=14,!=15.*,<17 currently isn't available on s390x.
   skip: True  # [s390x or py<37]
-  script: {{ PYTHON }} -m pip install --install-option="--skip-npm" --no-deps --no-build-isolation . -vv
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
   entry_points:
     - jupyter-lab = jupyterlab.labapp:main
     - jupyter-labextension = jupyterlab.labextensions:main
@@ -40,7 +40,7 @@ requirements:
     - jupyter_core
     - jupyter_server >=1.16,<3
     - jupyter_server_ydoc >=0.8.0,<0.9.0
-    - jupyter_ydoc >=0.2.3,<0.3
+    - jupyter_ydoc >=0.2.4,<0.3
     - jupyterlab_server >=2.19,<3
     - nbclassic
     - notebook <7


### PR DESCRIPTION
Changes:
- Update to 3.6.7

Need: JupyterLab 3.x users could affected by `CVE-2024-22421`

https://github.com/jupyterlab/jupyterlab/compare/v3.6.3...v3.6.7#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52