### PR TITLE
jupyterlab 4.2.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/jupyterlab_server-feedstock/pr26/5f984bc
-  - https://staging.continuum.io/prefect/fs/nodejs-feedstock/pr20/a60c2a9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/jupyterlab_server-feedstock/pr26/5f984bc
+  - https://staging.continuum.io/prefect/fs/nodejs-feedstock/pr20/a60c2a9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "4.0.11" %}
+{% set version = "4.2.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d1aec24712566bc25a36229788242778e498ca4088028e2f9aa156b8b7fdc8fc
+  sha256: ae7f3a1b8cb88b4f55009ce79fa7c06f99d70cd63601ee4aa91815d054f46f75
 
 build:
   number: 0 # trigger
@@ -28,30 +28,31 @@ app:
 
 requirements:
   host:
-    - hatchling >=1.5.0
+    - hatchling >=1.21.1
     - hatch-jupyter-builder >=0.3.2
     - pip
     - python
   run:
     - python
     - async-lru >=1.0.0
+    - httpx >=0.25.0
+    - importlib_resources >=1.4   # [py<39]
     - importlib-metadata >=4.8.3  # [py<310]
-    - importlib_resources >=1.4  # [py<39]
-    - ipykernel
+    - ipykernel >=6.5.0
     - jinja2 >=3.0.3
     - jupyter_core
-    - jupyter-lsp >=2.0.0
     - jupyter_server >=2.4.0,<3
-    - jupyterlab_server >=2.19.0,<3
+    - jupyter-lsp >=2.0.0
+    - jupyterlab_server >=2.27.1,<3
     - notebook-shim >=0.2
     - packaging
-    - traitlets
+    - tomli >=1.2.2  # [py<311]
     - tornado >=6.2.0
-    - tomli  # [py<311]
+    - traitlets
   run_constrained:
-    - nodejs >=18.0.0
+    - nodejs >=20.0.0,<21.0.0
 
-test:  
+test:
   source_files:
     - conftest.py
   requires:
@@ -64,6 +65,7 @@ test:
     - pytest-tornasync
     - requests
     - nodejs
+    - virtualenv
   imports:
     - jupyterlab
   commands:
@@ -78,6 +80,8 @@ test:
     - jupyter server extension list
     - jupyter server extension list 1>server_extensions 2>&1
     - cat server_extensions | rg "jupyterlab.*{{ version.replace(".", "\\.") }}.*OK"  # [not win]
+    # jupyterlab extensions require nodejs >=20.0.0,<21.0.0,
+    # see https://github.com/jupyterlab/jupyterlab/blob/v4.2.5/docs/source/extension/extension_tutorial.rst#install-nodejs-jupyterlab-etc-in-a-conda-environment
     - jupyter lab build --dev-build=False --minimize=False
     - jupyter lab clean
     - python -m pytest -vv --pyargs jupyterlab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,8 @@ requirements:
     - jupyterlab_server >=2.27.1,<3
     - notebook-shim >=0.2
     - packaging
+    # setuptools is required at runtime https://github.com/jupyterlab/jupyterlab/blob/v4.2.5/jupyterlab/federated_labextensions.py#L464.
+    - setuptools >=40.1.0
     - tomli >=1.2.2  # [py<311]
     - tornado >=6.2.0
     - traitlets


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5602](https://anaconda.atlassian.net/browse/PKG-5602) 
- [Upstream repository](https://github.com/jupyterlab/jupyterlab/tree/v4.2.5)
- Requirements: https://github.com/jupyterlab/jupyterlab/blob/v4.2.5/pyproject.toml

### Explanation of changes:

- Update `hatchling` pinning in `host`
- Update runtime pinnings and add `httpx >=0.25.0`
- Use `nodejs  >=20.0.0,<21.0.0` in `run_constrained`, see links: 
  - https://github.com/jupyterlab/jupyterlab/pull/15996 and 
  - https://github.com/jupyterlab/jupyterlab/blob/v4.2.5/docs/source/extension/extension_tutorial.rst#install-nodejs-jupyterlab-etc-in-a-conda-environment.  
  - I'm updating our `nodejs` here https://github.com/AnacondaRecipes/nodejs-feedstock/pull/20
- Add `virtualenv` to `test/requires`

### Notes:

- Addressing CVE-2024-43805

[PKG-5602]: https://anaconda.atlassian.net/browse/PKG-5602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ