### PR TITLE
jupyterlab 4.4.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "4.4.6" %}
+{% set version = "4.4.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e0b720ff5392846bdbc01745f32f29f4d001c071a4bff94d8b516ba89b5a4157
+  sha256: 8c8e225492f4513ebde9bbbc00a05b651ab9a1f5b0013015d96fabf671c37188
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-9589](https://anaconda.atlassian.net/browse/PKG-9589) 
- [Upstream repository](https://github.com/jupyterlab/jupyterlab/tree/v4.4.7)
- [Upstream changelog/diff](https://github.com/jupyterlab/jupyterlab/releases)

### Explanation of changes:

- Update version number


[PKG-9589]: https://anaconda.atlassian.net/browse/PKG-9589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ