### PR TITLE
jupyterlab 4.5.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab" %}
-{% set version = "4.5.6" %}
+{% set version = "4.5.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 642fe2cfe7f0f5922a8a558ba7a0d246c7bc133b708dfe43f7b3a826d163cf42
+  sha256: 55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-14381](https://anaconda.atlassian.net/browse/PKG-14381)
- [Upstream repository](https://github.com/jupyterlab/jupyterlab/tree/v4.5.7)
- [Upstream changelog/diff](https://github.com/jupyterlab/jupyterlab/releases)

### Explanation of changes:

- new version number
- addresses CVE-2026-42266


[PKG-14381]: https://anaconda.atlassian.net/browse/PKG-14381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ