### PR TITLE
jupyterlab 4.5.9 -- restore app section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: dd79a073fecae7a39066ea99e4627ed6c76269ac926e95a810e1e1df6358d865
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
   entry_points:
@@ -18,6 +18,12 @@ build:
     - jupyter-lab = jupyterlab.labapp:main
     - jupyter-labextension = jupyterlab.labextensions:main
     - jupyter-labhub = jupyterlab.labhubapp:main
+
+app:
+  entry: jupyter lab
+  icon: icon.png
+  summary: JupyterLab {{ version }}
+  type: desk
 
 requirements:
   host:


### PR DESCRIPTION
jupyterlab 4.5.9

**Destination channel:** defaults

### Links

- [PKG-17295](https://anaconda.atlassian.net/browse/PKG-17295) 
- [Upstream repository](https://github.com/jupyterlab/jupyterlab)

### Explanation of changes:

- the app section was removed and no-one noticed until deployed with Navigator
- bump the build number

This will require an attendant hotfix to get Navigator to use this new version: https://github.com/AnacondaRecipes/repodata-hotfixes/pull/340



[PKG-17295]: https://anaconda.atlassian.net/browse/PKG-17295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ