### PR TITLE
jupyterlab 4.6.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,19 @@ source:
   sha256: e18ce8b34f3de350e93cd5b2c4f3ae884cbe266eb76bf5d6825a4ed34c13bcff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
   entry_points:
     - jupyter-lab = jupyterlab.labapp:main
     - jupyter-labextension = jupyterlab.labextensions:main
     - jupyter-labhub = jupyterlab.labhubapp:main
+
+app:
+  entry: jupyter lab
+  icon: icon.png
+  summary: JupyterLab {{ version }}
+  type: desk
 
 requirements:
   host:


### PR DESCRIPTION
jupyterlab 4.6.2 

**Destination channel:** Defaults

### Links

- [PKG-17297]
- dev_url:        https://github.com/jupyterlab/jupyterlab/tree/v4.6.2
- conda_forge:    https://github.com/conda-forge/jupyterlab-feedstock
- pypi:           https://pypi.org/project/jupyterlab/4.6.2
- pypi inspector: https://inspector.pypi.io/project/jupyterlab/4.6.2

### Explanation of changes:

- new build number
- restore app section (accidentally removed in 4.5.9 build 0)


[PKG-17297]: https://anaconda.atlassian.net/browse/PKG-17297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ